### PR TITLE
fix typescript typing reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"types": "./dist/index.d.ts",
 	"exports": {
 		"types": "./dist/index.d.ts",
 		"default": "./dist/index.js"


### PR DESCRIPTION
it seems that the types property was removed from the package.json here:
https://github.com/sindresorhus/memoize/commit/3afdfaf4f7862f835d01f250779091fe66e00f32#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L23