### PR TITLE
Let `maxAge` option accept a function

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ export type Options<
 
 	@default Infinity
 	*/
-	readonly maxAge?: number;
+	readonly maxAge?: number | ((...arguments_: Parameters<FunctionToMemoize>) => number);
 
 	/**
 	Determines the cache key for storing the result based on the function arguments. By default, __only the first argument is considered__ and it only works with [primitives](https://developer.mozilla.org/en-US/docs/Glossary/Primitive).
@@ -68,7 +68,8 @@ export type Options<
 /**
 [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input.
 
-@param fn - The function to be memoized.
+@param function_ - The function to be memoized.
+@param options - Options for the memoization.
 
 @example
 ```
@@ -129,15 +130,17 @@ export default function memoize<
 
 		const result = function_.apply(this, arguments_) as ReturnType<FunctionToMemoize>;
 
+		const computedMaxAge = typeof maxAge === 'function' ? maxAge(...arguments_) : maxAge;
+
 		cache.set(key, {
 			data: result,
-			maxAge: maxAge ? Date.now() + maxAge : Number.POSITIVE_INFINITY,
+			maxAge: computedMaxAge ? Date.now() + computedMaxAge : Number.POSITIVE_INFINITY,
 		});
 
-		if (typeof maxAge === 'number' && maxAge !== Number.POSITIVE_INFINITY) {
+		if (computedMaxAge && computedMaxAge > 0 && computedMaxAge !== Number.POSITIVE_INFINITY) {
 			const timer = setTimeout(() => {
 				cache.delete(key);
-			}, maxAge);
+			}, computedMaxAge);
 
 			timer.unref?.();
 
@@ -221,7 +224,7 @@ export function memoizeDecorator<
 /**
 Clear all cached data of a memoized function.
 
-@param fn - The memoized function.
+@param function_ - The memoized function.
 */
 export function memoizeClear(function_: AnyFunction): void {
 	const cache = cacheStore.get(function_);

--- a/index.ts
+++ b/index.ts
@@ -25,6 +25,8 @@ export type Options<
 	/**
 	Milliseconds until the cache entry expires.
 
+	If a function is provided, it receives the arguments and must return the max age.
+
 	@default Infinity
 	*/
 	readonly maxAge?: number | ((...arguments_: Parameters<FunctionToMemoize>) => number);

--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,6 @@ export type Options<
 [Memoize](https://en.wikipedia.org/wiki/Memoization) functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input.
 
 @param function_ - The function to be memoized.
-@param options - Options for the memoization.
 
 @example
 ```

--- a/readme.md
+++ b/readme.md
@@ -183,8 +183,9 @@ Type: `object`
 
 ##### maxAge
 
-Type: `number`\
-Default: `Infinity`
+Type: `number` | `Function`\
+Default: `Infinity`\
+Example: `arg => arg < new Date() ? Infinity : 60_000`
 
 Milliseconds until the cache entry expires.
 

--- a/readme.md
+++ b/readme.md
@@ -185,9 +185,11 @@ Type: `object`
 
 Type: `number` | `Function`\
 Default: `Infinity`\
-Example: `arg => arg < new Date() ? Infinity : 60_000`
+Example: `arguments_ => arguments_ < new Date() ? Infinity : 60_000`
 
 Milliseconds until the cache entry expires.
+
+If a function is provided, it receives the arguments and must return the max age.
 
 ##### cacheKey
 

--- a/test.ts
+++ b/test.ts
@@ -339,3 +339,21 @@ test('maxAge - high concurrency', async t => {
 	await delay(100);
 	t.is(memoized(), 1);
 });
+
+test('maxAge dependent on function parameters', async t => {
+	let index = 0;
+	const fixture = (x: number) => index++;
+	const memoized = memoize(fixture, {
+		maxAge: x => x * 100,
+	});
+
+	t.is(memoized(1), 0); // Initial call, cached
+	await delay(50);
+	t.is(memoized(1), 0); // Still cached
+	await delay(60);
+	t.is(memoized(1), 1); // Cache expired, should compute again
+
+	t.is(memoized(2), 2); // Initial call with different parameter, cached
+	await delay(210);
+	t.is(memoized(2), 3); // Cache expired, should compute again
+});


### PR DESCRIPTION
hey, first of all I really love your package ❤️ 

i have the use case to fetch the weather from an external api which should be memorized. 

the weather is dependent of the `address` and and `timestamp`. 

if the `timestamp` is in the past, the result should be cached infinite, otherwise for e. g. 1 hour. 

to make this happen the `maxAge` should be computed from the arguments (like the cache key) 

what do you think?  