### PR TITLE
Fix timer ID memory leak with `maxAge` option

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -142,6 +142,7 @@ export default function memoize<
 		if (computedMaxAge && computedMaxAge > 0 && computedMaxAge !== Number.POSITIVE_INFINITY) {
 			const timer = setTimeout(() => {
 				cache.delete(key);
+				cacheTimerStore.get(function_)?.delete(timer as unknown as number);
 			}, computedMaxAge);
 
 			timer.unref?.();


### PR DESCRIPTION
Fixes #103

I haven't been able to write a test for it, but I believe this fixes #103. Even if not, it does fix a bug.